### PR TITLE
feat: 管理者用dashboardと詳細画面の作成

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "firebase": "^11.7.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -14781,6 +14782,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.0.tgz",
+      "integrity": "sha512-GGufuHIVCJDbnIAXP3P9Sxzq3UUsddG3rrI3ut1q6m0FI6vxVBF3JoPQ38+W/blslLH4a5Yutp8drkEpXoddGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.0.tgz",
+      "integrity": "sha512-DYgm6RDEuKdopSyGOWZGtDfSm7Aofb8CCzgkliTjtu/eDuB0gcsv6qdFhhi8HdtmA+KHkt5MfZ5K2PdzjugYsA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -15686,6 +15734,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "firebase": "^11.7.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,18 @@
-import React from "react";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Form from "./components/Form";
+import AdminDashboard from "./components/AdminDashboard";
+import AdminQuestionDetail from "./components/AdminQuestionDetail";
 
 function App() {
-  return <Form />;
+  return (
+    <Router>
+      <Routes>
+        <Route path="/" element={<Form />} />
+        <Route path="/admin/dashboard" element={<AdminDashboard />} />
+        <Route path="/admin/dashboard/detail/:id" element={<AdminQuestionDetail />} />
+      </Routes>
+    </Router>
+  );
 }
 
 export default App;

--- a/frontend/src/components/AdminDashboard.tsx
+++ b/frontend/src/components/AdminDashboard.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import { getFirestore, collection, query, where, onSnapshot } from "firebase/firestore";
+
+interface Question {
+  id: string;
+  questionId: string;
+  faculty: string;
+  grade: string;
+  topic: string;
+  submittedAt: any; // Firestore Timestamp
+  status: string;
+  repliedBy?: string;
+}
+
+export default function AdminDashboard() {
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const db = getFirestore();
+
+  useEffect(() => {
+    const q = query(collection(db, "questions"));
+    const unsubscribe = onSnapshot(q, (snapshot) => {
+      const list = snapshot.docs.map((doc) => ({
+        id: doc.id,
+        ...doc.data(),
+      })) as Question[];
+
+      // questionIdの数値部分で降順ソート
+      const sorted = list.sort((a, b) =>
+        parseInt(b.questionId.replace("#", "")) - parseInt(a.questionId.replace("#", ""))
+      );
+
+      setQuestions(sorted);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-bold mb-4">質問一覧</h1>
+      <table className="w-full border-collapse border border-gray-300">
+      <thead>
+        <tr>
+          <th className="border px-4 py-2">ID</th>
+          <th className="border px-4 py-2">カテゴリ</th>
+          <th className="border px-4 py-2">学科</th>
+          <th className="border px-4 py-2">学年</th>
+          <th className="border px-4 py-2">投稿日時</th>
+          <th className="border px-4 py-2">ステータス</th>
+          <th className="border px-4 py-2">対応者</th>
+        </tr>
+      </thead>
+      <tbody>
+        {questions.map((q) => (
+          <tr
+            key={q.id}
+            className={`cursor-pointer hover:bg-gray-100 ${q.status === "replied" ? "text-gray-400" : ""}`}
+            onClick={() => {
+              window.location.href = `/admin/dashboard/detail/${q.id}`;
+            }}
+          >
+            <td className="border px-4 py-2">{q.questionId}</td>
+            <td className="border px-4 py-2">{q.topic}</td>
+            <td className="border px-4 py-2">{q.faculty}</td>
+            <td className="border px-4 py-2">{q.grade}</td>
+            <td className="border px-4 py-2">
+              {q.submittedAt?.toDate().toLocaleString([], { dateStyle: 'short', timeStyle: 'short'})}
+            </td>
+            <td className="border px-4 py-2">{q.status === "replied" ? "対応済み" : "未対応"}</td>
+            <td className="border px-4 py-2">{q.repliedBy || ""}</td>
+          </tr>
+        ))}
+      </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/AdminQuestionDetail.tsx
+++ b/frontend/src/components/AdminQuestionDetail.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  getFirestore,
+  doc,
+  getDoc,
+  updateDoc,
+  collection,
+  addDoc,
+  serverTimestamp,
+} from "firebase/firestore";
+
+interface QuestionData {
+  name: string;
+  faculty: string;
+  grade: string;
+  email: string;
+  questionText: string;
+  topic: string;
+  status: string;
+  submittedAt: any;
+  repliedBy?: string;
+  repliedAt?: any;
+  reply?: string;
+}
+
+export default function AdminQuestionDetail() {
+  const { id } = useParams();
+  const db = getFirestore();
+
+  const [data, setData] = useState<QuestionData | null>(null);
+  const [replyText, setReplyText] = useState("");
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!id) return;
+      const docRef = doc(db, "questions", id);
+      const docSnap = await getDoc(docRef);
+      if (docSnap.exists()) {
+        const docData = docSnap.data() as QuestionData;
+        setData(docData);
+        setReplyText(docData.reply || ""); // ← 回答を初期表示
+      }
+    };
+    fetchData();
+  }, [id]);
+
+  const handleSubmit = async () => {
+    if (!id || !data) return;
+
+    const docRef = doc(db, "questions", id);
+    await updateDoc(docRef, {
+      reply: replyText,
+      repliedAt: serverTimestamp(),
+      repliedBy: "管理者", // ここは後でログインユーザー名にしてもいい
+      status: "replied",
+    });
+
+    await addDoc(collection(db, "archives"), {
+      topic: data.topic,
+      grade: data.grade,
+      questionText: data.questionText,
+      submittedAt: data.submittedAt,
+    });
+
+    alert("回答を送信しました！");
+    window.location.href = "/admin/dashboard";
+  };
+
+  if (!data) return <div className="p-4">読み込み中...</div>;
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto space-y-4">
+      <h1 className="text-xl font-bold">質問詳細</h1>
+      <p><strong>名前:</strong> {data.name}</p>
+      <p><strong>学科:</strong> {data.faculty}</p>
+      <p><strong>学年:</strong> {data.grade}</p>
+      <p><strong>カテゴリ:</strong> {data.topic}</p>
+      <p><strong>質問内容:</strong> {data.questionText}</p>
+
+      {data.status === "replied" && (
+        <p>
+          <strong>回答内容（回答者: {data.repliedBy || "不明"}）:</strong>
+        </p>
+      )}
+
+      <textarea
+        className="w-full border p-2"
+        rows={10}
+        placeholder="ここに回答を記入"
+        value={replyText}
+        onChange={(e) => setReplyText(e.target.value)}
+        readOnly={data.status === "replied"}
+      />
+
+      {data.status !== "replied" && (
+        <button
+          onClick={handleSubmit}
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          回答を送信する
+        </button>
+      )}
+        <div className="flex justify-center">
+          <button
+            onClick={() => navigate("/admin/dashboard")}
+            className="bg-gray-500 text-white px-4 py-2 rounded"
+          >
+            戻る
+          </button>
+        </div>
+    </div>
+  );
+}

--- a/functions/firebase-debug.log
+++ b/functions/firebase-debug.log
@@ -193,3 +193,715 @@
 [debug] [2025-05-21T12:36:52.297Z] >>> [apiv2][query] GET https://cloudfunctions.googleapis.com/v1/operations/cXVlc3Rpb24tc3VwcG9ydC91cy1jZW50cmFsMS9hZGRRdWVzdGlvbklkL1pXUmZVbXdyR1hv [none]
 [debug] [2025-05-21T12:36:52.695Z] <<< [apiv2][status] GET https://cloudfunctions.googleapis.com/v1/operations/cXVlc3Rpb24tc3VwcG9ydC91cy1jZW50cmFsMS9hZGRRdWVzdGlvbklkL1pXUmZVbXdyR1hv 200
 [debug] [2025-05-21T12:36:52.695Z] <<< [apiv2][body] GET https://cloudfunctions.googleapis.com/v1/operations/cXVlc3Rpb24tc3VwcG9ydC91cy1jZW50cmFsMS9hZGRRdWVzdGlvbklkL1pXUmZVbXdyR1hv {"name":"operations/cXVlc3Rpb24tc3VwcG9ydC91cy1jZW50cmFsMS9hZGRRdWVzdGlvbklkL1pXUmZVbXdyR1hv","metadata":{"@type":"type.googleapis.com/google.cloud.functions.v1.OperationMetadataV1","target":"projects/question-support/locations/us-central1/functions/addQuestionId","type":"UPDATE_FUNCTION","request":{"@type":"type.googleapis.com/google.cloud.functions.v1.CloudFunction","name":"projects/question-support/locations/us-central1/functions/addQuestionId","eventTrigger":{"eventType":"providers/cloud.firestore/eventTypes/document.create","resource":"projects/question-support/databases/(default)/documents/questions/{docId}","service":"firestore.googleapis.com"},"status":"OFFLINE","entryPoint":"addQuestionId","timeout":"60s","availableMemoryMb":256,"serviceAccountEmail":"question-support@appspot.gserviceaccount.com","updateTime":"2025-05-21T12:33:34.008Z","versionId":"1","labels":{"deployment-tool":"cli-firebase","firebase-functions-hash":"0d139a11c4c61d30fbc736ad713b7db596e96a5b"},"sourceUploadUrl":"https://storage.googleapis.com/uploads-465932626544.us-central1.cloudfunctions.appspot.com/299ecbdf-ccb4-4168-8ffe-5671fe768423.zip?GoogleAccessId=service-4878361862@gcf-admin-robot.iam.gserviceaccount.com&Expires=1747832800&Signature=MvDAE7%2FV4oET9relTxh8lLThD9PLQQffIIWwOUXIyNYVNAo%2Bt2BzrMx9vpfPCQPRp8UKIDBTxMDpVAAMMx7eMdVxZ61jgkRD0rHhEF2uvHs8pQ3nXQU2mP%2B16HoY6RcL8sA0fWvjdvskJxQaU5sXx2SBlj%2FQOkS3bNF3WoUOEnFZJZYPEWMaUOdNNumkUCaXwTv7YxsOnktQXq4bT3U5ph%2F02NsSaAgQUqkpiSxWYR%2BTqfX92DV4BPNLKpX0kADkhuiN5ITFMGkbg2n3e7A9bqIJjZ167x3dB4a7PvuvZnEyBLLDFhBC1VreLu1Dy5RzxiixfA3nyb0pUyDDkOuD6w%3D%3D","environmentVariables":{"FIREBASE_CONFIG":"{\"projectId\":\"question-support\",\"storageBucket\":\"question-support.firebasestorage.app\"}","GCLOUD_PROJECT":"question-support","EVENTARC_CLOUD_EVENT_SOURCE":"projects/question-support/locations/us-central1/functions/addQuestionId"},"runtime":"nodejs18","maxInstances":3000,"ingressSettings":"ALLOW_ALL","buildId":"c001cee5-4147-41e9-9b83-501f5de3c6d4","buildEnvironmentVariables":{"GOOGLE_NODE_RUN_SCRIPTS":""},"buildName":"projects/4878361862/locations/us-central1/builds/c001cee5-4147-41e9-9b83-501f5de3c6d4","dockerRegistry":"ARTIFACT_REGISTRY","automaticUpdatePolicy":{},"buildServiceAccount":"projects/question-support/serviceAccounts/4878361862-compute@developer.gserviceaccount.com"},"versionId":"2","updateTime":"2025-05-21T12:36:42Z","buildId":"fdc6e43e-856b-487a-a110-0c93a6a8e081","buildName":"projects/4878361862/locations/us-central1/builds/fdc6e43e-856b-487a-a110-0c93a6a8e081"}}
+[debug] [2025-05-22T09:54:09.108Z] ----------------------------------------------------------------------
+[debug] [2025-05-22T09:54:09.110Z] Command:       /usr/local/bin/node /usr/local/bin/firebase emulators:start --only functions
+[debug] [2025-05-22T09:54:09.110Z] CLI Version:   13.35.1
+[debug] [2025-05-22T09:54:09.110Z] Platform:      linux
+[debug] [2025-05-22T09:54:09.110Z] Node Version:  v18.20.8
+[debug] [2025-05-22T09:54:09.111Z] Time:          Thu May 22 2025 09:54:09 GMT+0000 (Coordinated Universal Time)
+[debug] [2025-05-22T09:54:09.111Z] ----------------------------------------------------------------------
+[debug] 
+[debug] [2025-05-22T09:54:09.113Z] >>> [apiv2][query] GET https://firebase-public.firebaseio.com/cli.json [none]
+[warn] ⚠  functions: The functions emulator is configured but there is no functions source directory. Have you run firebase init functions? {"metadata":{"emulator":{"name":"functions"},"message":"The functions emulator is configured but there is no functions source directory. Have you run firebase init functions?"}}
+[debug] [2025-05-22T09:54:09.144Z] > command requires scopes: ["email","openid","https://www.googleapis.com/auth/cloudplatformprojects.readonly","https://www.googleapis.com/auth/firebase","https://www.googleapis.com/auth/cloud-platform"]
+[debug] Failed to authenticate, have you run firebase login?
+[warn] ⚠  emulators: You are not currently authenticated so some features may not work correctly. Please run firebase login to authenticate the CLI. 
+[warn] ⚠  Could not find config (firebase.json) so using defaults. 
+[info] i  emulators: Starting emulators: functions {"metadata":{"emulator":{"name":"hub"},"message":"Starting emulators: functions"}}
+[warn] ⚠  hub: Error when trying to check port 4400 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4400 {"metadata":{"emulator":{"name":"hub"},"message":"Error when trying to check port 4400 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4400"}}
+[warn] ⚠  hub: Port 4400 is available on 127.0.0.1 but not ::1. This may cause issues with some clients. {"metadata":{"emulator":{"name":"hub"},"message":"Port 4400 is available on 127.0.0.1 but not ::1. This may cause issues with some clients."}}
+[warn] ⚠  hub: If you encounter connectivity issues, consider switching to a different port or explicitly specifying "host": "<ip address>" instead of hostname in firebase.json {"metadata":{"emulator":{"name":"hub"},"message":"If you encounter connectivity issues, consider switching to a different port or explicitly specifying \"host\": \"<ip address>\" instead of hostname in firebase.json"}}
+[warn] ⚠  ui: Error when trying to check port 4000 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4000 {"metadata":{"emulator":{"name":"ui"},"message":"Error when trying to check port 4000 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4000"}}
+[warn] ⚠  ui: Port 4000 is available on 127.0.0.1 but not ::1. This may cause issues with some clients. {"metadata":{"emulator":{"name":"ui"},"message":"Port 4000 is available on 127.0.0.1 but not ::1. This may cause issues with some clients."}}
+[warn] ⚠  ui: If you encounter connectivity issues, consider switching to a different port or explicitly specifying "host": "<ip address>" instead of hostname in firebase.json {"metadata":{"emulator":{"name":"ui"},"message":"If you encounter connectivity issues, consider switching to a different port or explicitly specifying \"host\": \"<ip address>\" instead of hostname in firebase.json"}}
+[warn] ⚠  logging: Error when trying to check port 4500 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4500 {"metadata":{"emulator":{"name":"logging"},"message":"Error when trying to check port 4500 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4500"}}
+[warn] ⚠  logging: Port 4500 is available on 127.0.0.1 but not ::1. This may cause issues with some clients. {"metadata":{"emulator":{"name":"logging"},"message":"Port 4500 is available on 127.0.0.1 but not ::1. This may cause issues with some clients."}}
+[warn] ⚠  logging: If you encounter connectivity issues, consider switching to a different port or explicitly specifying "host": "<ip address>" instead of hostname in firebase.json {"metadata":{"emulator":{"name":"logging"},"message":"If you encounter connectivity issues, consider switching to a different port or explicitly specifying \"host\": \"<ip address>\" instead of hostname in firebase.json"}}
+[debug] [2025-05-22T09:54:09.188Z] assigned listening specs for emulators {"user":{"hub":[{"address":"127.0.0.1","family":"IPv4","port":4400}],"ui":[{"address":"127.0.0.1","family":"IPv4","port":4000}],"logging":[{"address":"127.0.0.1","family":"IPv4","port":4500}]},"metadata":{"message":"assigned listening specs for emulators"}}
+[debug] [2025-05-22T09:54:09.191Z] [hub] writing locator at /tmp/hub-question-support.json
+[warn] ⚠  functions: The functions emulator is configured but there is no functions source directory. Have you run firebase init functions? {"metadata":{"emulator":{"name":"functions"},"message":"The functions emulator is configured but there is no functions source directory. Have you run firebase init functions?"}}
+[info] i  ui: downloading ui-v1.14.0.zip... {"metadata":{"emulator":{"name":"ui"},"message":"downloading ui-v1.14.0.zip..."}}
+[debug] [2025-05-22T09:54:09.200Z] >>> [apiv2][query] GET https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.14.0.zip 
+[debug] [2025-05-22T09:54:09.347Z] <<< [apiv2][status] GET https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.14.0.zip 200
+[debug] [2025-05-22T09:54:09.347Z] <<< [apiv2][body] GET https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.14.0.zip [stream]
+[debug] [2025-05-22T09:54:09.579Z] <<< [apiv2][status] GET https://firebase-public.firebaseio.com/cli.json 200
+[debug] [2025-05-22T09:54:09.579Z] <<< [apiv2][body] GET https://firebase-public.firebaseio.com/cli.json {"cloudBuildErrorAfter":1594252800000,"cloudBuildWarnAfter":1590019200000,"defaultNode10After":1594252800000,"minVersion":"3.0.5","node8DeploysDisabledAfter":1613390400000,"node8RuntimeDisabledAfter":1615809600000,"node8WarnAfter":1600128000000}
+[debug] [2025-05-22T09:54:10.389Z] Data is 3615311
+[debug] [2025-05-22T09:54:10.389Z] [unzip] Entry: client/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T09:54:10.389Z] [unzip] Processing entry: client/
+[debug] [2025-05-22T09:54:10.390Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/
+[debug] [2025-05-22T09:54:10.390Z] [unzip] Entry: client/favicon-16x16.png (compressed_size=293 bytes, uncompressed_size=293 bytes)
+[debug] [2025-05-22T09:54:10.390Z] [unzip] Processing entry: client/favicon-16x16.png
+[debug] [2025-05-22T09:54:10.390Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T09:54:10.390Z] [unzip] Writing file: /root/.cache/firebase/emulators/ui-v1.14.0/client/favicon-16x16.png
+[debug] [2025-05-22T09:54:10.391Z] [unzip] Entry: client/safari-pinned-tab.svg (compressed_size=1433 bytes, uncompressed_size=2611 bytes)
+[debug] [2025-05-22T09:54:10.391Z] [unzip] Processing entry: client/safari-pinned-tab.svg
+[debug] [2025-05-22T09:54:10.391Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T09:54:10.391Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/safari-pinned-tab.svg
+[debug] [2025-05-22T09:54:10.394Z] [unzip] Entry: client/favicon.ico (compressed_size=2933 bytes, uncompressed_size=13294 bytes)
+[debug] [2025-05-22T09:54:10.394Z] [unzip] Processing entry: client/favicon.ico
+[debug] [2025-05-22T09:54:10.394Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T09:54:10.394Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/favicon.ico
+[debug] [2025-05-22T09:54:10.395Z] [unzip] Entry: client/index.html (compressed_size=1363 bytes, uncompressed_size=3071 bytes)
+[debug] [2025-05-22T09:54:10.395Z] [unzip] Processing entry: client/index.html
+[debug] [2025-05-22T09:54:10.395Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T09:54:10.395Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/index.html
+[debug] [2025-05-22T09:54:10.396Z] [unzip] Entry: client/android-chrome-192x192.png (compressed_size=2684 bytes, uncompressed_size=2684 bytes)
+[debug] [2025-05-22T09:54:10.396Z] [unzip] Processing entry: client/android-chrome-192x192.png
+[debug] [2025-05-22T09:54:10.396Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T09:54:10.397Z] [unzip] Writing file: /root/.cache/firebase/emulators/ui-v1.14.0/client/android-chrome-192x192.png
+[debug] [2025-05-22T09:54:10.397Z] [unzip] Entry: client/apple-touch-icon.png (compressed_size=2123 bytes, uncompressed_size=2152 bytes)
+[debug] [2025-05-22T09:54:10.397Z] [unzip] Processing entry: client/apple-touch-icon.png
+[debug] [2025-05-22T09:54:10.397Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T09:54:10.397Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/apple-touch-icon.png
+[debug] [2025-05-22T09:54:10.398Z] [unzip] Entry: client/android-chrome-512x512.png (compressed_size=5369 bytes, uncompressed_size=5411 bytes)
+[debug] [2025-05-22T09:54:10.398Z] [unzip] Processing entry: client/android-chrome-512x512.png
+[debug] [2025-05-22T09:54:10.398Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T09:54:10.398Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/android-chrome-512x512.png
+[debug] [2025-05-22T09:54:10.399Z] [unzip] Entry: client/manifest.json (compressed_size=245 bytes, uncompressed_size=551 bytes)
+[debug] [2025-05-22T09:54:10.399Z] [unzip] Processing entry: client/manifest.json
+[debug] [2025-05-22T09:54:10.399Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T09:54:10.399Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/manifest.json
+[debug] [2025-05-22T09:54:10.400Z] [unzip] Entry: client/robots.txt (compressed_size=26 bytes, uncompressed_size=26 bytes)
+[debug] [2025-05-22T09:54:10.400Z] [unzip] Processing entry: client/robots.txt
+[debug] [2025-05-22T09:54:10.400Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T09:54:10.400Z] [unzip] Writing file: /root/.cache/firebase/emulators/ui-v1.14.0/client/robots.txt
+[debug] [2025-05-22T09:54:10.400Z] [unzip] Entry: client/mstile-150x150.png (compressed_size=2034 bytes, uncompressed_size=2034 bytes)
+[debug] [2025-05-22T09:54:10.400Z] [unzip] Processing entry: client/mstile-150x150.png
+[debug] [2025-05-22T09:54:10.400Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T09:54:10.400Z] [unzip] Writing file: /root/.cache/firebase/emulators/ui-v1.14.0/client/mstile-150x150.png
+[debug] [2025-05-22T09:54:10.401Z] [unzip] Entry: client/assets/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T09:54:10.401Z] [unzip] Processing entry: client/assets/
+[debug] [2025-05-22T09:54:10.401Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/
+[debug] [2025-05-22T09:54:10.401Z] [unzip] Entry: client/assets/index-ClZTY_JS.js.map (compressed_size=2328270 bytes, uncompressed_size=9947004 bytes)
+[debug] [2025-05-22T09:54:10.401Z] [unzip] Processing entry: client/assets/index-ClZTY_JS.js.map
+[debug] [2025-05-22T09:54:10.401Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets
+[debug] [2025-05-22T09:54:10.401Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/index-ClZTY_JS.js.map
+[debug] [2025-05-22T09:54:10.476Z] [unzip] Entry: client/assets/index-ClZTY_JS.js (compressed_size=567195 bytes, uncompressed_size=2035940 bytes)
+[debug] [2025-05-22T09:54:10.477Z] [unzip] Processing entry: client/assets/index-ClZTY_JS.js
+[debug] [2025-05-22T09:54:10.477Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets
+[debug] [2025-05-22T09:54:10.477Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/index-ClZTY_JS.js
+[debug] [2025-05-22T09:54:10.496Z] [unzip] Entry: client/assets/index-BdgySamB.css (compressed_size=35979 bytes, uncompressed_size=298654 bytes)
+[debug] [2025-05-22T09:54:10.496Z] [unzip] Processing entry: client/assets/index-BdgySamB.css
+[debug] [2025-05-22T09:54:10.496Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets
+[debug] [2025-05-22T09:54:10.497Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/index-BdgySamB.css
+[debug] [2025-05-22T09:54:10.500Z] [unzip] Entry: client/assets/extensions/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T09:54:10.500Z] [unzip] Processing entry: client/assets/extensions/
+[debug] [2025-05-22T09:54:10.500Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/extensions/
+[debug] [2025-05-22T09:54:10.500Z] [unzip] Entry: client/assets/extensions/default-extension.png (compressed_size=1646 bytes, uncompressed_size=1657 bytes)
+[debug] [2025-05-22T09:54:10.500Z] [unzip] Processing entry: client/assets/extensions/default-extension.png
+[debug] [2025-05-22T09:54:10.500Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/extensions
+[debug] [2025-05-22T09:54:10.500Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/extensions/default-extension.png
+[debug] [2025-05-22T09:54:10.501Z] [unzip] Entry: client/assets/img/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T09:54:10.501Z] [unzip] Processing entry: client/assets/img/
+[debug] [2025-05-22T09:54:10.501Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/img/
+[debug] [2025-05-22T09:54:10.501Z] [unzip] Entry: client/assets/img/database.png (compressed_size=29449 bytes, uncompressed_size=29988 bytes)
+[debug] [2025-05-22T09:54:10.501Z] [unzip] Processing entry: client/assets/img/database.png
+[debug] [2025-05-22T09:54:10.501Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/img
+[debug] [2025-05-22T09:54:10.502Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/img/database.png
+[debug] [2025-05-22T09:54:10.502Z] [unzip] Entry: client/assets/provider-icons/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T09:54:10.502Z] [unzip] Processing entry: client/assets/provider-icons/
+[debug] [2025-05-22T09:54:10.502Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/
+[debug] [2025-05-22T09:54:10.502Z] [unzip] Entry: client/assets/provider-icons/auth_service_saml.svg (compressed_size=575 bytes, uncompressed_size=1226 bytes)
+[debug] [2025-05-22T09:54:10.503Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_saml.svg
+[debug] [2025-05-22T09:54:10.503Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T09:54:10.503Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_saml.svg
+[debug] [2025-05-22T09:54:10.503Z] [unzip] Entry: client/assets/provider-icons/auth_service_phone.svg (compressed_size=261 bytes, uncompressed_size=414 bytes)
+[debug] [2025-05-22T09:54:10.503Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_phone.svg
+[debug] [2025-05-22T09:54:10.503Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T09:54:10.503Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_phone.svg
+[debug] [2025-05-22T09:54:10.504Z] [unzip] Entry: client/assets/provider-icons/auth_service_facebook.svg (compressed_size=289 bytes, uncompressed_size=457 bytes)
+[debug] [2025-05-22T09:54:10.504Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_facebook.svg
+[debug] [2025-05-22T09:54:10.504Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T09:54:10.504Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_facebook.svg
+[debug] [2025-05-22T09:54:10.504Z] [unzip] Entry: client/assets/provider-icons/auth_service_game_center.svg (compressed_size=991 bytes, uncompressed_size=3921 bytes)
+[debug] [2025-05-22T09:54:10.505Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_game_center.svg
+[debug] [2025-05-22T09:54:10.505Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T09:54:10.505Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_game_center.svg
+[debug] [2025-05-22T09:54:10.505Z] [unzip] Entry: client/assets/provider-icons/auth_service_apple.svg (compressed_size=230 bytes, uncompressed_size=334 bytes)
+[debug] [2025-05-22T09:54:10.505Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_apple.svg
+[debug] [2025-05-22T09:54:10.505Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T09:54:10.505Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_apple.svg
+[debug] [2025-05-22T09:54:10.506Z] [unzip] Entry: client/assets/provider-icons/auth_service_github.svg (compressed_size=466 bytes, uncompressed_size=838 bytes)
+[debug] [2025-05-22T09:54:10.506Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_github.svg
+[debug] [2025-05-22T09:54:10.506Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T09:54:10.506Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_github.svg
+[debug] [2025-05-22T09:54:10.507Z] [unzip] Entry: client/assets/provider-icons/auth_service_mslive.svg (compressed_size=203 bytes, uncompressed_size=378 bytes)
+[debug] [2025-05-22T09:54:10.507Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_mslive.svg
+[debug] [2025-05-22T09:54:10.507Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T09:54:10.507Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_mslive.svg
+[debug] [2025-05-22T09:54:10.507Z] [unzip] Entry: client/assets/provider-icons/auth_service_yahoo.svg (compressed_size=577 bytes, uncompressed_size=1182 bytes)
+[debug] [2025-05-22T09:54:10.507Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_yahoo.svg
+[debug] [2025-05-22T09:54:10.507Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T09:54:10.508Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_yahoo.svg
+[debug] [2025-05-22T09:54:10.508Z] [unzip] Entry: client/assets/provider-icons/auth_service_twitter.svg (compressed_size=444 bytes, uncompressed_size=751 bytes)
+[debug] [2025-05-22T09:54:10.508Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_twitter.svg
+[debug] [2025-05-22T09:54:10.508Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T09:54:10.508Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_twitter.svg
+[debug] [2025-05-22T09:54:10.509Z] [unzip] Entry: client/assets/provider-icons/auth_service_play_games.svg (compressed_size=565 bytes, uncompressed_size=1173 bytes)
+[debug] [2025-05-22T09:54:10.509Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_play_games.svg
+[debug] [2025-05-22T09:54:10.509Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T09:54:10.509Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_play_games.svg
+[debug] [2025-05-22T09:54:10.509Z] [unzip] Entry: client/assets/provider-icons/auth_service_email.svg (compressed_size=228 bytes, uncompressed_size=326 bytes)
+[debug] [2025-05-22T09:54:10.509Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_email.svg
+[debug] [2025-05-22T09:54:10.509Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T09:54:10.510Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_email.svg
+[debug] [2025-05-22T09:54:10.510Z] [unzip] Entry: client/assets/provider-icons/auth_service_google.svg (compressed_size=409 bytes, uncompressed_size=720 bytes)
+[debug] [2025-05-22T09:54:10.510Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_google.svg
+[debug] [2025-05-22T09:54:10.510Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T09:54:10.510Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_google.svg
+[debug] [2025-05-22T09:54:10.511Z] [unzip] Entry: client/assets/provider-icons/auth_service_oidc.svg (compressed_size=414 bytes, uncompressed_size=858 bytes)
+[debug] [2025-05-22T09:54:10.511Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_oidc.svg
+[debug] [2025-05-22T09:54:10.511Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T09:54:10.511Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_oidc.svg
+[debug] [2025-05-22T09:54:10.512Z] [unzip] Entry: client/browserconfig.xml (compressed_size=491 bytes, uncompressed_size=822 bytes)
+[debug] [2025-05-22T09:54:10.512Z] [unzip] Processing entry: client/browserconfig.xml
+[debug] [2025-05-22T09:54:10.512Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T09:54:10.512Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/browserconfig.xml
+[debug] [2025-05-22T09:54:10.512Z] [unzip] Entry: client/favicon-32x32.png (compressed_size=475 bytes, uncompressed_size=475 bytes)
+[debug] [2025-05-22T09:54:10.512Z] [unzip] Processing entry: client/favicon-32x32.png
+[debug] [2025-05-22T09:54:10.512Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T09:54:10.513Z] [unzip] Writing file: /root/.cache/firebase/emulators/ui-v1.14.0/client/favicon-32x32.png
+[debug] [2025-05-22T09:54:10.513Z] [unzip] Entry: server/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T09:54:10.513Z] [unzip] Processing entry: server/
+[debug] [2025-05-22T09:54:10.513Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server/
+[debug] [2025-05-22T09:54:10.513Z] [unzip] Entry: server/server.mjs.map (compressed_size=296496 bytes, uncompressed_size=1355667 bytes)
+[debug] [2025-05-22T09:54:10.513Z] [unzip] Processing entry: server/server.mjs.map
+[debug] [2025-05-22T09:54:10.513Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server
+[debug] [2025-05-22T09:54:10.513Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/server/server.mjs.map
+[debug] [2025-05-22T09:54:10.522Z] [unzip] Entry: server/server.mjs (compressed_size=315701 bytes, uncompressed_size=1172682 bytes)
+[debug] [2025-05-22T09:54:10.522Z] [unzip] Processing entry: server/server.mjs
+[debug] [2025-05-22T09:54:10.522Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server
+[debug] [2025-05-22T09:54:10.522Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/server/server.mjs
+[debug] [2025-05-22T09:54:10.533Z] [unzip] Entry: server/assets/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T09:54:10.533Z] [unzip] Processing entry: server/assets/
+[debug] [2025-05-22T09:54:10.533Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server/assets/
+[debug] [2025-05-22T09:54:10.533Z] [unzip] Entry: server/assets/multipart-parser-DGCUZdXu.mjs.map (compressed_size=4791 bytes, uncompressed_size=17918 bytes)
+[debug] [2025-05-22T09:54:10.533Z] [unzip] Processing entry: server/assets/multipart-parser-DGCUZdXu.mjs.map
+[debug] [2025-05-22T09:54:10.533Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server/assets
+[debug] [2025-05-22T09:54:10.534Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/server/assets/multipart-parser-DGCUZdXu.mjs.map
+[debug] [2025-05-22T09:54:10.534Z] [unzip] Entry: server/assets/multipart-parser-DGCUZdXu.mjs (compressed_size=2621 bytes, uncompressed_size=10390 bytes)
+[debug] [2025-05-22T09:54:10.534Z] [unzip] Processing entry: server/assets/multipart-parser-DGCUZdXu.mjs
+[debug] [2025-05-22T09:54:10.534Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server/assets
+[debug] [2025-05-22T09:54:10.534Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/server/assets/multipart-parser-DGCUZdXu.mjs
+[debug] [2025-05-22T09:54:10.537Z] Could not find VSCode notification endpoint: FetchError: request to http://localhost:40001/vscode/notify failed, reason: connect ECONNREFUSED 127.0.0.1:40001. If you are not running the Firebase Data Connect VSCode extension, this is expected and not an issue.
+[info] 
+┌─────────────────────────────────────────────────────────────┐
+│ ✔  All emulators ready! It is now safe to connect your app. │
+│ i  View Emulator UI at http://127.0.0.1:4000/               │
+└─────────────────────────────────────────────────────────────┘
+
+┌───────────┬──────────────────────────────────┬─────────────────────┐
+│ Emulator  │ Host:Port                        │ View in Emulator UI │
+├───────────┼──────────────────────────────────┼─────────────────────┤
+│ Functions │ Failed to initialize (see above) │                     │
+└───────────┴──────────────────────────────────┴─────────────────────┘
+  Emulator Hub host: 127.0.0.1 port: 4400
+  Other reserved ports: 4500
+
+Issues? Report them at https://github.com/firebase/firebase-tools/issues and attach the *-debug.log files.
+ 
+[debug] [2025-05-22T10:12:41.641Z] ----------------------------------------------------------------------
+[debug] [2025-05-22T10:12:41.642Z] Command:       /usr/local/bin/node /usr/local/bin/firebase emulators:start --only functions
+[debug] [2025-05-22T10:12:41.642Z] CLI Version:   13.35.1
+[debug] [2025-05-22T10:12:41.642Z] Platform:      linux
+[debug] [2025-05-22T10:12:41.642Z] Node Version:  v18.20.8
+[debug] [2025-05-22T10:12:41.643Z] Time:          Thu May 22 2025 10:12:41 GMT+0000 (Coordinated Universal Time)
+[debug] [2025-05-22T10:12:41.643Z] ----------------------------------------------------------------------
+[debug] 
+[warn] ⚠  functions: The functions emulator is configured but there is no functions source directory. Have you run firebase init functions? {"metadata":{"emulator":{"name":"functions"},"message":"The functions emulator is configured but there is no functions source directory. Have you run firebase init functions?"}}
+[debug] [2025-05-22T10:12:41.649Z] > command requires scopes: ["email","openid","https://www.googleapis.com/auth/cloudplatformprojects.readonly","https://www.googleapis.com/auth/firebase","https://www.googleapis.com/auth/cloud-platform"]
+[debug] Failed to authenticate, have you run firebase login?
+[warn] ⚠  emulators: You are not currently authenticated so some features may not work correctly. Please run firebase login to authenticate the CLI. 
+[warn] ⚠  Could not find config (firebase.json) so using defaults. 
+[info] i  emulators: Starting emulators: functions {"metadata":{"emulator":{"name":"hub"},"message":"Starting emulators: functions"}}
+[warn] ⚠  hub: Error when trying to check port 4400 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4400 {"metadata":{"emulator":{"name":"hub"},"message":"Error when trying to check port 4400 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4400"}}
+[warn] ⚠  hub: Port 4400 is available on 127.0.0.1 but not ::1. This may cause issues with some clients. {"metadata":{"emulator":{"name":"hub"},"message":"Port 4400 is available on 127.0.0.1 but not ::1. This may cause issues with some clients."}}
+[warn] ⚠  hub: If you encounter connectivity issues, consider switching to a different port or explicitly specifying "host": "<ip address>" instead of hostname in firebase.json {"metadata":{"emulator":{"name":"hub"},"message":"If you encounter connectivity issues, consider switching to a different port or explicitly specifying \"host\": \"<ip address>\" instead of hostname in firebase.json"}}
+[warn] ⚠  ui: Error when trying to check port 4000 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4000 {"metadata":{"emulator":{"name":"ui"},"message":"Error when trying to check port 4000 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4000"}}
+[warn] ⚠  ui: Port 4000 is available on 127.0.0.1 but not ::1. This may cause issues with some clients. {"metadata":{"emulator":{"name":"ui"},"message":"Port 4000 is available on 127.0.0.1 but not ::1. This may cause issues with some clients."}}
+[warn] ⚠  ui: If you encounter connectivity issues, consider switching to a different port or explicitly specifying "host": "<ip address>" instead of hostname in firebase.json {"metadata":{"emulator":{"name":"ui"},"message":"If you encounter connectivity issues, consider switching to a different port or explicitly specifying \"host\": \"<ip address>\" instead of hostname in firebase.json"}}
+[warn] ⚠  logging: Error when trying to check port 4500 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4500 {"metadata":{"emulator":{"name":"logging"},"message":"Error when trying to check port 4500 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4500"}}
+[warn] ⚠  logging: Port 4500 is available on 127.0.0.1 but not ::1. This may cause issues with some clients. {"metadata":{"emulator":{"name":"logging"},"message":"Port 4500 is available on 127.0.0.1 but not ::1. This may cause issues with some clients."}}
+[warn] ⚠  logging: If you encounter connectivity issues, consider switching to a different port or explicitly specifying "host": "<ip address>" instead of hostname in firebase.json {"metadata":{"emulator":{"name":"logging"},"message":"If you encounter connectivity issues, consider switching to a different port or explicitly specifying \"host\": \"<ip address>\" instead of hostname in firebase.json"}}
+[debug] [2025-05-22T10:12:41.681Z] assigned listening specs for emulators {"user":{"hub":[{"address":"127.0.0.1","family":"IPv4","port":4400}],"ui":[{"address":"127.0.0.1","family":"IPv4","port":4000}],"logging":[{"address":"127.0.0.1","family":"IPv4","port":4500}]},"metadata":{"message":"assigned listening specs for emulators"}}
+[warn] ⚠  emulators: It seems that you are running multiple instances of the emulator suite for project question-support. This may result in unexpected behavior. 
+[debug] [2025-05-22T10:12:41.684Z] [hub] writing locator at /tmp/hub-question-support.json
+[warn] ⚠  functions: The functions emulator is configured but there is no functions source directory. Have you run firebase init functions? {"metadata":{"emulator":{"name":"functions"},"message":"The functions emulator is configured but there is no functions source directory. Have you run firebase init functions?"}}
+[debug] [2025-05-22T10:12:41.692Z] Could not find VSCode notification endpoint: FetchError: request to http://localhost:40001/vscode/notify failed, reason: connect ECONNREFUSED 127.0.0.1:40001. If you are not running the Firebase Data Connect VSCode extension, this is expected and not an issue.
+[info] 
+┌─────────────────────────────────────────────────────────────┐
+│ ✔  All emulators ready! It is now safe to connect your app. │
+│ i  View Emulator UI at http://127.0.0.1:4000/               │
+└─────────────────────────────────────────────────────────────┘
+
+┌───────────┬──────────────────────────────────┬─────────────────────┐
+│ Emulator  │ Host:Port                        │ View in Emulator UI │
+├───────────┼──────────────────────────────────┼─────────────────────┤
+│ Functions │ Failed to initialize (see above) │                     │
+└───────────┴──────────────────────────────────┴─────────────────────┘
+  Emulator Hub host: 127.0.0.1 port: 4400
+  Other reserved ports: 4500
+
+Issues? Report them at https://github.com/firebase/firebase-tools/issues and attach the *-debug.log files.
+ 
+[debug] [2025-05-22T10:16:18.611Z] ----------------------------------------------------------------------
+[debug] [2025-05-22T10:16:18.612Z] Command:       /usr/local/bin/node /usr/local/bin/firebase emulators:start --only functions
+[debug] [2025-05-22T10:16:18.612Z] CLI Version:   13.35.1
+[debug] [2025-05-22T10:16:18.612Z] Platform:      linux
+[debug] [2025-05-22T10:16:18.612Z] Node Version:  v18.20.8
+[debug] [2025-05-22T10:16:18.613Z] Time:          Thu May 22 2025 10:16:18 GMT+0000 (Coordinated Universal Time)
+[debug] [2025-05-22T10:16:18.613Z] ----------------------------------------------------------------------
+[debug] 
+[warn] ⚠  functions: The functions emulator is configured but there is no functions source directory. Have you run firebase init functions? {"metadata":{"emulator":{"name":"functions"},"message":"The functions emulator is configured but there is no functions source directory. Have you run firebase init functions?"}}
+[debug] [2025-05-22T10:16:18.618Z] > command requires scopes: ["email","openid","https://www.googleapis.com/auth/cloudplatformprojects.readonly","https://www.googleapis.com/auth/firebase","https://www.googleapis.com/auth/cloud-platform"]
+[debug] Failed to authenticate, have you run firebase login?
+[warn] ⚠  emulators: You are not currently authenticated so some features may not work correctly. Please run firebase login to authenticate the CLI. 
+[warn] ⚠  Could not find config (firebase.json) so using defaults. 
+[info] i  emulators: Starting emulators: functions {"metadata":{"emulator":{"name":"hub"},"message":"Starting emulators: functions"}}
+[warn] ⚠  hub: Error when trying to check port 4400 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4400 {"metadata":{"emulator":{"name":"hub"},"message":"Error when trying to check port 4400 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4400"}}
+[warn] ⚠  hub: Port 4400 is available on 127.0.0.1 but not ::1. This may cause issues with some clients. {"metadata":{"emulator":{"name":"hub"},"message":"Port 4400 is available on 127.0.0.1 but not ::1. This may cause issues with some clients."}}
+[warn] ⚠  hub: If you encounter connectivity issues, consider switching to a different port or explicitly specifying "host": "<ip address>" instead of hostname in firebase.json {"metadata":{"emulator":{"name":"hub"},"message":"If you encounter connectivity issues, consider switching to a different port or explicitly specifying \"host\": \"<ip address>\" instead of hostname in firebase.json"}}
+[warn] ⚠  ui: Error when trying to check port 4000 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4000 {"metadata":{"emulator":{"name":"ui"},"message":"Error when trying to check port 4000 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4000"}}
+[warn] ⚠  ui: Port 4000 is available on 127.0.0.1 but not ::1. This may cause issues with some clients. {"metadata":{"emulator":{"name":"ui"},"message":"Port 4000 is available on 127.0.0.1 but not ::1. This may cause issues with some clients."}}
+[warn] ⚠  ui: If you encounter connectivity issues, consider switching to a different port or explicitly specifying "host": "<ip address>" instead of hostname in firebase.json {"metadata":{"emulator":{"name":"ui"},"message":"If you encounter connectivity issues, consider switching to a different port or explicitly specifying \"host\": \"<ip address>\" instead of hostname in firebase.json"}}
+[warn] ⚠  logging: Error when trying to check port 4500 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4500 {"metadata":{"emulator":{"name":"logging"},"message":"Error when trying to check port 4500 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4500"}}
+[warn] ⚠  logging: Port 4500 is available on 127.0.0.1 but not ::1. This may cause issues with some clients. {"metadata":{"emulator":{"name":"logging"},"message":"Port 4500 is available on 127.0.0.1 but not ::1. This may cause issues with some clients."}}
+[warn] ⚠  logging: If you encounter connectivity issues, consider switching to a different port or explicitly specifying "host": "<ip address>" instead of hostname in firebase.json {"metadata":{"emulator":{"name":"logging"},"message":"If you encounter connectivity issues, consider switching to a different port or explicitly specifying \"host\": \"<ip address>\" instead of hostname in firebase.json"}}
+[debug] [2025-05-22T10:16:18.650Z] assigned listening specs for emulators {"user":{"hub":[{"address":"127.0.0.1","family":"IPv4","port":4400}],"ui":[{"address":"127.0.0.1","family":"IPv4","port":4000}],"logging":[{"address":"127.0.0.1","family":"IPv4","port":4500}]},"metadata":{"message":"assigned listening specs for emulators"}}
+[warn] ⚠  emulators: It seems that you are running multiple instances of the emulator suite for project question-support. This may result in unexpected behavior. 
+[debug] [2025-05-22T10:16:18.652Z] [hub] writing locator at /tmp/hub-question-support.json
+[warn] ⚠  functions: The functions emulator is configured but there is no functions source directory. Have you run firebase init functions? {"metadata":{"emulator":{"name":"functions"},"message":"The functions emulator is configured but there is no functions source directory. Have you run firebase init functions?"}}
+[debug] [2025-05-22T10:16:18.660Z] Could not find VSCode notification endpoint: FetchError: request to http://localhost:40001/vscode/notify failed, reason: connect ECONNREFUSED 127.0.0.1:40001. If you are not running the Firebase Data Connect VSCode extension, this is expected and not an issue.
+[info] 
+┌─────────────────────────────────────────────────────────────┐
+│ ✔  All emulators ready! It is now safe to connect your app. │
+│ i  View Emulator UI at http://127.0.0.1:4000/               │
+└─────────────────────────────────────────────────────────────┘
+
+┌───────────┬──────────────────────────────────┬─────────────────────┐
+│ Emulator  │ Host:Port                        │ View in Emulator UI │
+├───────────┼──────────────────────────────────┼─────────────────────┤
+│ Functions │ Failed to initialize (see above) │                     │
+└───────────┴──────────────────────────────────┴─────────────────────┘
+  Emulator Hub host: 127.0.0.1 port: 4400
+  Other reserved ports: 4500
+
+Issues? Report them at https://github.com/firebase/firebase-tools/issues and attach the *-debug.log files.
+ 
+[debug] [2025-05-22T11:21:31.425Z] ----------------------------------------------------------------------
+[debug] [2025-05-22T11:21:31.426Z] Command:       /usr/local/bin/node /usr/local/bin/firebase emulators:start --only functions
+[debug] [2025-05-22T11:21:31.427Z] CLI Version:   13.35.1
+[debug] [2025-05-22T11:21:31.427Z] Platform:      linux
+[debug] [2025-05-22T11:21:31.427Z] Node Version:  v18.20.8
+[debug] [2025-05-22T11:21:31.427Z] Time:          Thu May 22 2025 11:21:31 GMT+0000 (Coordinated Universal Time)
+[debug] [2025-05-22T11:21:31.427Z] ----------------------------------------------------------------------
+[debug] 
+[debug] [2025-05-22T11:21:31.429Z] >>> [apiv2][query] GET https://firebase-public.firebaseio.com/cli.json [none]
+[warn] ⚠  functions: The functions emulator is configured but there is no functions source directory. Have you run firebase init functions? {"metadata":{"emulator":{"name":"functions"},"message":"The functions emulator is configured but there is no functions source directory. Have you run firebase init functions?"}}
+[debug] [2025-05-22T11:21:31.460Z] > command requires scopes: ["email","openid","https://www.googleapis.com/auth/cloudplatformprojects.readonly","https://www.googleapis.com/auth/firebase","https://www.googleapis.com/auth/cloud-platform"]
+[debug] Failed to authenticate, have you run firebase login?
+[warn] ⚠  emulators: You are not currently authenticated so some features may not work correctly. Please run firebase login to authenticate the CLI. 
+[warn] ⚠  Could not find config (firebase.json) so using defaults. 
+[info] i  emulators: Starting emulators: functions {"metadata":{"emulator":{"name":"hub"},"message":"Starting emulators: functions"}}
+[warn] ⚠  hub: Error when trying to check port 4400 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4400 {"metadata":{"emulator":{"name":"hub"},"message":"Error when trying to check port 4400 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4400"}}
+[warn] ⚠  hub: Port 4400 is available on 127.0.0.1 but not ::1. This may cause issues with some clients. {"metadata":{"emulator":{"name":"hub"},"message":"Port 4400 is available on 127.0.0.1 but not ::1. This may cause issues with some clients."}}
+[warn] ⚠  hub: If you encounter connectivity issues, consider switching to a different port or explicitly specifying "host": "<ip address>" instead of hostname in firebase.json {"metadata":{"emulator":{"name":"hub"},"message":"If you encounter connectivity issues, consider switching to a different port or explicitly specifying \"host\": \"<ip address>\" instead of hostname in firebase.json"}}
+[warn] ⚠  ui: Error when trying to check port 4000 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4000 {"metadata":{"emulator":{"name":"ui"},"message":"Error when trying to check port 4000 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4000"}}
+[warn] ⚠  ui: Port 4000 is available on 127.0.0.1 but not ::1. This may cause issues with some clients. {"metadata":{"emulator":{"name":"ui"},"message":"Port 4000 is available on 127.0.0.1 but not ::1. This may cause issues with some clients."}}
+[warn] ⚠  ui: If you encounter connectivity issues, consider switching to a different port or explicitly specifying "host": "<ip address>" instead of hostname in firebase.json {"metadata":{"emulator":{"name":"ui"},"message":"If you encounter connectivity issues, consider switching to a different port or explicitly specifying \"host\": \"<ip address>\" instead of hostname in firebase.json"}}
+[warn] ⚠  logging: Error when trying to check port 4500 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4500 {"metadata":{"emulator":{"name":"logging"},"message":"Error when trying to check port 4500 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4500"}}
+[warn] ⚠  logging: Port 4500 is available on 127.0.0.1 but not ::1. This may cause issues with some clients. {"metadata":{"emulator":{"name":"logging"},"message":"Port 4500 is available on 127.0.0.1 but not ::1. This may cause issues with some clients."}}
+[warn] ⚠  logging: If you encounter connectivity issues, consider switching to a different port or explicitly specifying "host": "<ip address>" instead of hostname in firebase.json {"metadata":{"emulator":{"name":"logging"},"message":"If you encounter connectivity issues, consider switching to a different port or explicitly specifying \"host\": \"<ip address>\" instead of hostname in firebase.json"}}
+[debug] [2025-05-22T11:21:31.514Z] assigned listening specs for emulators {"user":{"hub":[{"address":"127.0.0.1","family":"IPv4","port":4400}],"ui":[{"address":"127.0.0.1","family":"IPv4","port":4000}],"logging":[{"address":"127.0.0.1","family":"IPv4","port":4500}]},"metadata":{"message":"assigned listening specs for emulators"}}
+[debug] [2025-05-22T11:21:31.517Z] [hub] writing locator at /tmp/hub-question-support.json
+[warn] ⚠  functions: The functions emulator is configured but there is no functions source directory. Have you run firebase init functions? {"metadata":{"emulator":{"name":"functions"},"message":"The functions emulator is configured but there is no functions source directory. Have you run firebase init functions?"}}
+[info] i  ui: downloading ui-v1.14.0.zip... {"metadata":{"emulator":{"name":"ui"},"message":"downloading ui-v1.14.0.zip..."}}
+[debug] [2025-05-22T11:21:31.524Z] >>> [apiv2][query] GET https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.14.0.zip 
+[debug] [2025-05-22T11:21:31.777Z] <<< [apiv2][status] GET https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.14.0.zip 200
+[debug] [2025-05-22T11:21:31.777Z] <<< [apiv2][body] GET https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.14.0.zip [stream]
+[debug] [2025-05-22T11:21:31.988Z] <<< [apiv2][status] GET https://firebase-public.firebaseio.com/cli.json 200
+[debug] [2025-05-22T11:21:31.988Z] <<< [apiv2][body] GET https://firebase-public.firebaseio.com/cli.json {"cloudBuildErrorAfter":1594252800000,"cloudBuildWarnAfter":1590019200000,"defaultNode10After":1594252800000,"minVersion":"3.0.5","node8DeploysDisabledAfter":1613390400000,"node8RuntimeDisabledAfter":1615809600000,"node8WarnAfter":1600128000000}
+[debug] [2025-05-22T11:21:33.316Z] Data is 3615311
+[debug] [2025-05-22T11:21:33.317Z] [unzip] Entry: client/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T11:21:33.317Z] [unzip] Processing entry: client/
+[debug] [2025-05-22T11:21:33.317Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/
+[debug] [2025-05-22T11:21:33.318Z] [unzip] Entry: client/favicon-16x16.png (compressed_size=293 bytes, uncompressed_size=293 bytes)
+[debug] [2025-05-22T11:21:33.318Z] [unzip] Processing entry: client/favicon-16x16.png
+[debug] [2025-05-22T11:21:33.318Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T11:21:33.318Z] [unzip] Writing file: /root/.cache/firebase/emulators/ui-v1.14.0/client/favicon-16x16.png
+[debug] [2025-05-22T11:21:33.319Z] [unzip] Entry: client/safari-pinned-tab.svg (compressed_size=1433 bytes, uncompressed_size=2611 bytes)
+[debug] [2025-05-22T11:21:33.319Z] [unzip] Processing entry: client/safari-pinned-tab.svg
+[debug] [2025-05-22T11:21:33.319Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T11:21:33.319Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/safari-pinned-tab.svg
+[debug] [2025-05-22T11:21:33.322Z] [unzip] Entry: client/favicon.ico (compressed_size=2933 bytes, uncompressed_size=13294 bytes)
+[debug] [2025-05-22T11:21:33.322Z] [unzip] Processing entry: client/favicon.ico
+[debug] [2025-05-22T11:21:33.323Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T11:21:33.323Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/favicon.ico
+[debug] [2025-05-22T11:21:33.324Z] [unzip] Entry: client/index.html (compressed_size=1363 bytes, uncompressed_size=3071 bytes)
+[debug] [2025-05-22T11:21:33.324Z] [unzip] Processing entry: client/index.html
+[debug] [2025-05-22T11:21:33.324Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T11:21:33.324Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/index.html
+[debug] [2025-05-22T11:21:33.325Z] [unzip] Entry: client/android-chrome-192x192.png (compressed_size=2684 bytes, uncompressed_size=2684 bytes)
+[debug] [2025-05-22T11:21:33.325Z] [unzip] Processing entry: client/android-chrome-192x192.png
+[debug] [2025-05-22T11:21:33.325Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T11:21:33.325Z] [unzip] Writing file: /root/.cache/firebase/emulators/ui-v1.14.0/client/android-chrome-192x192.png
+[debug] [2025-05-22T11:21:33.325Z] [unzip] Entry: client/apple-touch-icon.png (compressed_size=2123 bytes, uncompressed_size=2152 bytes)
+[debug] [2025-05-22T11:21:33.325Z] [unzip] Processing entry: client/apple-touch-icon.png
+[debug] [2025-05-22T11:21:33.325Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T11:21:33.325Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/apple-touch-icon.png
+[debug] [2025-05-22T11:21:33.326Z] [unzip] Entry: client/android-chrome-512x512.png (compressed_size=5369 bytes, uncompressed_size=5411 bytes)
+[debug] [2025-05-22T11:21:33.326Z] [unzip] Processing entry: client/android-chrome-512x512.png
+[debug] [2025-05-22T11:21:33.326Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T11:21:33.326Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/android-chrome-512x512.png
+[debug] [2025-05-22T11:21:33.327Z] [unzip] Entry: client/manifest.json (compressed_size=245 bytes, uncompressed_size=551 bytes)
+[debug] [2025-05-22T11:21:33.327Z] [unzip] Processing entry: client/manifest.json
+[debug] [2025-05-22T11:21:33.327Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T11:21:33.327Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/manifest.json
+[debug] [2025-05-22T11:21:33.328Z] [unzip] Entry: client/robots.txt (compressed_size=26 bytes, uncompressed_size=26 bytes)
+[debug] [2025-05-22T11:21:33.328Z] [unzip] Processing entry: client/robots.txt
+[debug] [2025-05-22T11:21:33.328Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T11:21:33.328Z] [unzip] Writing file: /root/.cache/firebase/emulators/ui-v1.14.0/client/robots.txt
+[debug] [2025-05-22T11:21:33.328Z] [unzip] Entry: client/mstile-150x150.png (compressed_size=2034 bytes, uncompressed_size=2034 bytes)
+[debug] [2025-05-22T11:21:33.328Z] [unzip] Processing entry: client/mstile-150x150.png
+[debug] [2025-05-22T11:21:33.328Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T11:21:33.328Z] [unzip] Writing file: /root/.cache/firebase/emulators/ui-v1.14.0/client/mstile-150x150.png
+[debug] [2025-05-22T11:21:33.329Z] [unzip] Entry: client/assets/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T11:21:33.329Z] [unzip] Processing entry: client/assets/
+[debug] [2025-05-22T11:21:33.329Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/
+[debug] [2025-05-22T11:21:33.329Z] [unzip] Entry: client/assets/index-ClZTY_JS.js.map (compressed_size=2328270 bytes, uncompressed_size=9947004 bytes)
+[debug] [2025-05-22T11:21:33.329Z] [unzip] Processing entry: client/assets/index-ClZTY_JS.js.map
+[debug] [2025-05-22T11:21:33.329Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets
+[debug] [2025-05-22T11:21:33.329Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/index-ClZTY_JS.js.map
+[debug] [2025-05-22T11:21:33.388Z] [unzip] Entry: client/assets/index-ClZTY_JS.js (compressed_size=567195 bytes, uncompressed_size=2035940 bytes)
+[debug] [2025-05-22T11:21:33.388Z] [unzip] Processing entry: client/assets/index-ClZTY_JS.js
+[debug] [2025-05-22T11:21:33.388Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets
+[debug] [2025-05-22T11:21:33.388Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/index-ClZTY_JS.js
+[debug] [2025-05-22T11:21:33.402Z] [unzip] Entry: client/assets/index-BdgySamB.css (compressed_size=35979 bytes, uncompressed_size=298654 bytes)
+[debug] [2025-05-22T11:21:33.402Z] [unzip] Processing entry: client/assets/index-BdgySamB.css
+[debug] [2025-05-22T11:21:33.402Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets
+[debug] [2025-05-22T11:21:33.402Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/index-BdgySamB.css
+[debug] [2025-05-22T11:21:33.404Z] [unzip] Entry: client/assets/extensions/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T11:21:33.404Z] [unzip] Processing entry: client/assets/extensions/
+[debug] [2025-05-22T11:21:33.404Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/extensions/
+[debug] [2025-05-22T11:21:33.404Z] [unzip] Entry: client/assets/extensions/default-extension.png (compressed_size=1646 bytes, uncompressed_size=1657 bytes)
+[debug] [2025-05-22T11:21:33.404Z] [unzip] Processing entry: client/assets/extensions/default-extension.png
+[debug] [2025-05-22T11:21:33.404Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/extensions
+[debug] [2025-05-22T11:21:33.405Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/extensions/default-extension.png
+[debug] [2025-05-22T11:21:33.405Z] [unzip] Entry: client/assets/img/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T11:21:33.405Z] [unzip] Processing entry: client/assets/img/
+[debug] [2025-05-22T11:21:33.405Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/img/
+[debug] [2025-05-22T11:21:33.405Z] [unzip] Entry: client/assets/img/database.png (compressed_size=29449 bytes, uncompressed_size=29988 bytes)
+[debug] [2025-05-22T11:21:33.406Z] [unzip] Processing entry: client/assets/img/database.png
+[debug] [2025-05-22T11:21:33.406Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/img
+[debug] [2025-05-22T11:21:33.406Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/img/database.png
+[debug] [2025-05-22T11:21:33.406Z] [unzip] Entry: client/assets/provider-icons/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T11:21:33.406Z] [unzip] Processing entry: client/assets/provider-icons/
+[debug] [2025-05-22T11:21:33.406Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/
+[debug] [2025-05-22T11:21:33.407Z] [unzip] Entry: client/assets/provider-icons/auth_service_saml.svg (compressed_size=575 bytes, uncompressed_size=1226 bytes)
+[debug] [2025-05-22T11:21:33.407Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_saml.svg
+[debug] [2025-05-22T11:21:33.407Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T11:21:33.407Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_saml.svg
+[debug] [2025-05-22T11:21:33.407Z] [unzip] Entry: client/assets/provider-icons/auth_service_phone.svg (compressed_size=261 bytes, uncompressed_size=414 bytes)
+[debug] [2025-05-22T11:21:33.408Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_phone.svg
+[debug] [2025-05-22T11:21:33.408Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T11:21:33.408Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_phone.svg
+[debug] [2025-05-22T11:21:33.408Z] [unzip] Entry: client/assets/provider-icons/auth_service_facebook.svg (compressed_size=289 bytes, uncompressed_size=457 bytes)
+[debug] [2025-05-22T11:21:33.408Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_facebook.svg
+[debug] [2025-05-22T11:21:33.408Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T11:21:33.408Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_facebook.svg
+[debug] [2025-05-22T11:21:33.409Z] [unzip] Entry: client/assets/provider-icons/auth_service_game_center.svg (compressed_size=991 bytes, uncompressed_size=3921 bytes)
+[debug] [2025-05-22T11:21:33.409Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_game_center.svg
+[debug] [2025-05-22T11:21:33.409Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T11:21:33.409Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_game_center.svg
+[debug] [2025-05-22T11:21:33.409Z] [unzip] Entry: client/assets/provider-icons/auth_service_apple.svg (compressed_size=230 bytes, uncompressed_size=334 bytes)
+[debug] [2025-05-22T11:21:33.409Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_apple.svg
+[debug] [2025-05-22T11:21:33.409Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T11:21:33.410Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_apple.svg
+[debug] [2025-05-22T11:21:33.410Z] [unzip] Entry: client/assets/provider-icons/auth_service_github.svg (compressed_size=466 bytes, uncompressed_size=838 bytes)
+[debug] [2025-05-22T11:21:33.410Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_github.svg
+[debug] [2025-05-22T11:21:33.410Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T11:21:33.410Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_github.svg
+[debug] [2025-05-22T11:21:33.411Z] [unzip] Entry: client/assets/provider-icons/auth_service_mslive.svg (compressed_size=203 bytes, uncompressed_size=378 bytes)
+[debug] [2025-05-22T11:21:33.411Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_mslive.svg
+[debug] [2025-05-22T11:21:33.411Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T11:21:33.411Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_mslive.svg
+[debug] [2025-05-22T11:21:33.411Z] [unzip] Entry: client/assets/provider-icons/auth_service_yahoo.svg (compressed_size=577 bytes, uncompressed_size=1182 bytes)
+[debug] [2025-05-22T11:21:33.411Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_yahoo.svg
+[debug] [2025-05-22T11:21:33.411Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T11:21:33.412Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_yahoo.svg
+[debug] [2025-05-22T11:21:33.412Z] [unzip] Entry: client/assets/provider-icons/auth_service_twitter.svg (compressed_size=444 bytes, uncompressed_size=751 bytes)
+[debug] [2025-05-22T11:21:33.412Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_twitter.svg
+[debug] [2025-05-22T11:21:33.412Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T11:21:33.412Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_twitter.svg
+[debug] [2025-05-22T11:21:33.413Z] [unzip] Entry: client/assets/provider-icons/auth_service_play_games.svg (compressed_size=565 bytes, uncompressed_size=1173 bytes)
+[debug] [2025-05-22T11:21:33.413Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_play_games.svg
+[debug] [2025-05-22T11:21:33.413Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T11:21:33.413Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_play_games.svg
+[debug] [2025-05-22T11:21:33.413Z] [unzip] Entry: client/assets/provider-icons/auth_service_email.svg (compressed_size=228 bytes, uncompressed_size=326 bytes)
+[debug] [2025-05-22T11:21:33.413Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_email.svg
+[debug] [2025-05-22T11:21:33.413Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T11:21:33.414Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_email.svg
+[debug] [2025-05-22T11:21:33.414Z] [unzip] Entry: client/assets/provider-icons/auth_service_google.svg (compressed_size=409 bytes, uncompressed_size=720 bytes)
+[debug] [2025-05-22T11:21:33.414Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_google.svg
+[debug] [2025-05-22T11:21:33.414Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T11:21:33.414Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_google.svg
+[debug] [2025-05-22T11:21:33.415Z] [unzip] Entry: client/assets/provider-icons/auth_service_oidc.svg (compressed_size=414 bytes, uncompressed_size=858 bytes)
+[debug] [2025-05-22T11:21:33.415Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_oidc.svg
+[debug] [2025-05-22T11:21:33.415Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T11:21:33.415Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_oidc.svg
+[debug] [2025-05-22T11:21:33.415Z] [unzip] Entry: client/browserconfig.xml (compressed_size=491 bytes, uncompressed_size=822 bytes)
+[debug] [2025-05-22T11:21:33.415Z] [unzip] Processing entry: client/browserconfig.xml
+[debug] [2025-05-22T11:21:33.415Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T11:21:33.416Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/browserconfig.xml
+[debug] [2025-05-22T11:21:33.416Z] [unzip] Entry: client/favicon-32x32.png (compressed_size=475 bytes, uncompressed_size=475 bytes)
+[debug] [2025-05-22T11:21:33.416Z] [unzip] Processing entry: client/favicon-32x32.png
+[debug] [2025-05-22T11:21:33.416Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T11:21:33.416Z] [unzip] Writing file: /root/.cache/firebase/emulators/ui-v1.14.0/client/favicon-32x32.png
+[debug] [2025-05-22T11:21:33.416Z] [unzip] Entry: server/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T11:21:33.416Z] [unzip] Processing entry: server/
+[debug] [2025-05-22T11:21:33.416Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server/
+[debug] [2025-05-22T11:21:33.416Z] [unzip] Entry: server/server.mjs.map (compressed_size=296496 bytes, uncompressed_size=1355667 bytes)
+[debug] [2025-05-22T11:21:33.416Z] [unzip] Processing entry: server/server.mjs.map
+[debug] [2025-05-22T11:21:33.416Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server
+[debug] [2025-05-22T11:21:33.417Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/server/server.mjs.map
+[debug] [2025-05-22T11:21:33.425Z] [unzip] Entry: server/server.mjs (compressed_size=315701 bytes, uncompressed_size=1172682 bytes)
+[debug] [2025-05-22T11:21:33.425Z] [unzip] Processing entry: server/server.mjs
+[debug] [2025-05-22T11:21:33.425Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server
+[debug] [2025-05-22T11:21:33.425Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/server/server.mjs
+[debug] [2025-05-22T11:21:33.434Z] [unzip] Entry: server/assets/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T11:21:33.435Z] [unzip] Processing entry: server/assets/
+[debug] [2025-05-22T11:21:33.435Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server/assets/
+[debug] [2025-05-22T11:21:33.435Z] [unzip] Entry: server/assets/multipart-parser-DGCUZdXu.mjs.map (compressed_size=4791 bytes, uncompressed_size=17918 bytes)
+[debug] [2025-05-22T11:21:33.435Z] [unzip] Processing entry: server/assets/multipart-parser-DGCUZdXu.mjs.map
+[debug] [2025-05-22T11:21:33.435Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server/assets
+[debug] [2025-05-22T11:21:33.435Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/server/assets/multipart-parser-DGCUZdXu.mjs.map
+[debug] [2025-05-22T11:21:33.436Z] [unzip] Entry: server/assets/multipart-parser-DGCUZdXu.mjs (compressed_size=2621 bytes, uncompressed_size=10390 bytes)
+[debug] [2025-05-22T11:21:33.436Z] [unzip] Processing entry: server/assets/multipart-parser-DGCUZdXu.mjs
+[debug] [2025-05-22T11:21:33.436Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server/assets
+[debug] [2025-05-22T11:21:33.436Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/server/assets/multipart-parser-DGCUZdXu.mjs
+[debug] [2025-05-22T11:21:33.439Z] Could not find VSCode notification endpoint: FetchError: request to http://localhost:40001/vscode/notify failed, reason: connect ECONNREFUSED 127.0.0.1:40001. If you are not running the Firebase Data Connect VSCode extension, this is expected and not an issue.
+[info] 
+┌─────────────────────────────────────────────────────────────┐
+│ ✔  All emulators ready! It is now safe to connect your app. │
+│ i  View Emulator UI at http://127.0.0.1:4000/               │
+└─────────────────────────────────────────────────────────────┘
+
+┌───────────┬──────────────────────────────────┬─────────────────────┐
+│ Emulator  │ Host:Port                        │ View in Emulator UI │
+├───────────┼──────────────────────────────────┼─────────────────────┤
+│ Functions │ Failed to initialize (see above) │                     │
+└───────────┴──────────────────────────────────┴─────────────────────┘
+  Emulator Hub host: 127.0.0.1 port: 4400
+  Other reserved ports: 4500
+
+Issues? Report them at https://github.com/firebase/firebase-tools/issues and attach the *-debug.log files.
+ 
+[debug] [2025-05-22T13:56:18.794Z] ----------------------------------------------------------------------
+[debug] [2025-05-22T13:56:18.795Z] Command:       /usr/local/bin/node /usr/local/bin/firebase emulators:start --only functions
+[debug] [2025-05-22T13:56:18.796Z] CLI Version:   13.35.1
+[debug] [2025-05-22T13:56:18.796Z] Platform:      linux
+[debug] [2025-05-22T13:56:18.796Z] Node Version:  v18.20.8
+[debug] [2025-05-22T13:56:18.797Z] Time:          Thu May 22 2025 13:56:18 GMT+0000 (Coordinated Universal Time)
+[debug] [2025-05-22T13:56:18.797Z] ----------------------------------------------------------------------
+[debug] 
+[debug] [2025-05-22T13:56:18.799Z] >>> [apiv2][query] GET https://firebase-public.firebaseio.com/cli.json [none]
+[warn] ⚠  functions: The functions emulator is configured but there is no functions source directory. Have you run firebase init functions? {"metadata":{"emulator":{"name":"functions"},"message":"The functions emulator is configured but there is no functions source directory. Have you run firebase init functions?"}}
+[debug] [2025-05-22T13:56:18.825Z] > command requires scopes: ["email","openid","https://www.googleapis.com/auth/cloudplatformprojects.readonly","https://www.googleapis.com/auth/firebase","https://www.googleapis.com/auth/cloud-platform"]
+[debug] Failed to authenticate, have you run firebase login?
+[warn] ⚠  emulators: You are not currently authenticated so some features may not work correctly. Please run firebase login to authenticate the CLI. 
+[warn] ⚠  Could not find config (firebase.json) so using defaults. 
+[info] i  emulators: Starting emulators: functions {"metadata":{"emulator":{"name":"hub"},"message":"Starting emulators: functions"}}
+[warn] ⚠  hub: Error when trying to check port 4400 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4400 {"metadata":{"emulator":{"name":"hub"},"message":"Error when trying to check port 4400 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4400"}}
+[warn] ⚠  hub: Port 4400 is available on 127.0.0.1 but not ::1. This may cause issues with some clients. {"metadata":{"emulator":{"name":"hub"},"message":"Port 4400 is available on 127.0.0.1 but not ::1. This may cause issues with some clients."}}
+[warn] ⚠  hub: If you encounter connectivity issues, consider switching to a different port or explicitly specifying "host": "<ip address>" instead of hostname in firebase.json {"metadata":{"emulator":{"name":"hub"},"message":"If you encounter connectivity issues, consider switching to a different port or explicitly specifying \"host\": \"<ip address>\" instead of hostname in firebase.json"}}
+[warn] ⚠  ui: Error when trying to check port 4000 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4000 {"metadata":{"emulator":{"name":"ui"},"message":"Error when trying to check port 4000 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4000"}}
+[warn] ⚠  ui: Port 4000 is available on 127.0.0.1 but not ::1. This may cause issues with some clients. {"metadata":{"emulator":{"name":"ui"},"message":"Port 4000 is available on 127.0.0.1 but not ::1. This may cause issues with some clients."}}
+[warn] ⚠  ui: If you encounter connectivity issues, consider switching to a different port or explicitly specifying "host": "<ip address>" instead of hostname in firebase.json {"metadata":{"emulator":{"name":"ui"},"message":"If you encounter connectivity issues, consider switching to a different port or explicitly specifying \"host\": \"<ip address>\" instead of hostname in firebase.json"}}
+[warn] ⚠  logging: Error when trying to check port 4500 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4500 {"metadata":{"emulator":{"name":"logging"},"message":"Error when trying to check port 4500 on ::1: Error: listen EADDRNOTAVAIL: address not available ::1:4500"}}
+[warn] ⚠  logging: Port 4500 is available on 127.0.0.1 but not ::1. This may cause issues with some clients. {"metadata":{"emulator":{"name":"logging"},"message":"Port 4500 is available on 127.0.0.1 but not ::1. This may cause issues with some clients."}}
+[warn] ⚠  logging: If you encounter connectivity issues, consider switching to a different port or explicitly specifying "host": "<ip address>" instead of hostname in firebase.json {"metadata":{"emulator":{"name":"logging"},"message":"If you encounter connectivity issues, consider switching to a different port or explicitly specifying \"host\": \"<ip address>\" instead of hostname in firebase.json"}}
+[debug] [2025-05-22T13:56:18.854Z] assigned listening specs for emulators {"user":{"hub":[{"address":"127.0.0.1","family":"IPv4","port":4400}],"ui":[{"address":"127.0.0.1","family":"IPv4","port":4000}],"logging":[{"address":"127.0.0.1","family":"IPv4","port":4500}]},"metadata":{"message":"assigned listening specs for emulators"}}
+[debug] [2025-05-22T13:56:18.857Z] [hub] writing locator at /tmp/hub-question-support.json
+[warn] ⚠  functions: The functions emulator is configured but there is no functions source directory. Have you run firebase init functions? {"metadata":{"emulator":{"name":"functions"},"message":"The functions emulator is configured but there is no functions source directory. Have you run firebase init functions?"}}
+[info] i  ui: downloading ui-v1.14.0.zip... {"metadata":{"emulator":{"name":"ui"},"message":"downloading ui-v1.14.0.zip..."}}
+[debug] [2025-05-22T13:56:18.865Z] >>> [apiv2][query] GET https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.14.0.zip 
+[debug] [2025-05-22T13:56:19.032Z] <<< [apiv2][status] GET https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.14.0.zip 200
+[debug] [2025-05-22T13:56:19.033Z] <<< [apiv2][body] GET https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.14.0.zip [stream]
+[debug] [2025-05-22T13:56:19.297Z] <<< [apiv2][status] GET https://firebase-public.firebaseio.com/cli.json 200
+[debug] [2025-05-22T13:56:19.298Z] <<< [apiv2][body] GET https://firebase-public.firebaseio.com/cli.json {"cloudBuildErrorAfter":1594252800000,"cloudBuildWarnAfter":1590019200000,"defaultNode10After":1594252800000,"minVersion":"3.0.5","node8DeploysDisabledAfter":1613390400000,"node8RuntimeDisabledAfter":1615809600000,"node8WarnAfter":1600128000000}
+[debug] [2025-05-22T13:56:19.886Z] Data is 3615311
+[debug] [2025-05-22T13:56:19.886Z] [unzip] Entry: client/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T13:56:19.886Z] [unzip] Processing entry: client/
+[debug] [2025-05-22T13:56:19.886Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/
+[debug] [2025-05-22T13:56:19.887Z] [unzip] Entry: client/favicon-16x16.png (compressed_size=293 bytes, uncompressed_size=293 bytes)
+[debug] [2025-05-22T13:56:19.887Z] [unzip] Processing entry: client/favicon-16x16.png
+[debug] [2025-05-22T13:56:19.887Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T13:56:19.887Z] [unzip] Writing file: /root/.cache/firebase/emulators/ui-v1.14.0/client/favicon-16x16.png
+[debug] [2025-05-22T13:56:19.887Z] [unzip] Entry: client/safari-pinned-tab.svg (compressed_size=1433 bytes, uncompressed_size=2611 bytes)
+[debug] [2025-05-22T13:56:19.888Z] [unzip] Processing entry: client/safari-pinned-tab.svg
+[debug] [2025-05-22T13:56:19.888Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T13:56:19.888Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/safari-pinned-tab.svg
+[debug] [2025-05-22T13:56:19.891Z] [unzip] Entry: client/favicon.ico (compressed_size=2933 bytes, uncompressed_size=13294 bytes)
+[debug] [2025-05-22T13:56:19.891Z] [unzip] Processing entry: client/favicon.ico
+[debug] [2025-05-22T13:56:19.891Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T13:56:19.891Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/favicon.ico
+[debug] [2025-05-22T13:56:19.892Z] [unzip] Entry: client/index.html (compressed_size=1363 bytes, uncompressed_size=3071 bytes)
+[debug] [2025-05-22T13:56:19.892Z] [unzip] Processing entry: client/index.html
+[debug] [2025-05-22T13:56:19.892Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T13:56:19.892Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/index.html
+[debug] [2025-05-22T13:56:19.893Z] [unzip] Entry: client/android-chrome-192x192.png (compressed_size=2684 bytes, uncompressed_size=2684 bytes)
+[debug] [2025-05-22T13:56:19.893Z] [unzip] Processing entry: client/android-chrome-192x192.png
+[debug] [2025-05-22T13:56:19.894Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T13:56:19.894Z] [unzip] Writing file: /root/.cache/firebase/emulators/ui-v1.14.0/client/android-chrome-192x192.png
+[debug] [2025-05-22T13:56:19.895Z] [unzip] Entry: client/apple-touch-icon.png (compressed_size=2123 bytes, uncompressed_size=2152 bytes)
+[debug] [2025-05-22T13:56:19.895Z] [unzip] Processing entry: client/apple-touch-icon.png
+[debug] [2025-05-22T13:56:19.895Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T13:56:19.895Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/apple-touch-icon.png
+[debug] [2025-05-22T13:56:19.896Z] [unzip] Entry: client/android-chrome-512x512.png (compressed_size=5369 bytes, uncompressed_size=5411 bytes)
+[debug] [2025-05-22T13:56:19.896Z] [unzip] Processing entry: client/android-chrome-512x512.png
+[debug] [2025-05-22T13:56:19.896Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T13:56:19.896Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/android-chrome-512x512.png
+[debug] [2025-05-22T13:56:19.897Z] [unzip] Entry: client/manifest.json (compressed_size=245 bytes, uncompressed_size=551 bytes)
+[debug] [2025-05-22T13:56:19.897Z] [unzip] Processing entry: client/manifest.json
+[debug] [2025-05-22T13:56:19.897Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T13:56:19.897Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/manifest.json
+[debug] [2025-05-22T13:56:19.898Z] [unzip] Entry: client/robots.txt (compressed_size=26 bytes, uncompressed_size=26 bytes)
+[debug] [2025-05-22T13:56:19.898Z] [unzip] Processing entry: client/robots.txt
+[debug] [2025-05-22T13:56:19.898Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T13:56:19.898Z] [unzip] Writing file: /root/.cache/firebase/emulators/ui-v1.14.0/client/robots.txt
+[debug] [2025-05-22T13:56:19.898Z] [unzip] Entry: client/mstile-150x150.png (compressed_size=2034 bytes, uncompressed_size=2034 bytes)
+[debug] [2025-05-22T13:56:19.898Z] [unzip] Processing entry: client/mstile-150x150.png
+[debug] [2025-05-22T13:56:19.898Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T13:56:19.898Z] [unzip] Writing file: /root/.cache/firebase/emulators/ui-v1.14.0/client/mstile-150x150.png
+[debug] [2025-05-22T13:56:19.898Z] [unzip] Entry: client/assets/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T13:56:19.898Z] [unzip] Processing entry: client/assets/
+[debug] [2025-05-22T13:56:19.898Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/
+[debug] [2025-05-22T13:56:19.899Z] [unzip] Entry: client/assets/index-ClZTY_JS.js.map (compressed_size=2328270 bytes, uncompressed_size=9947004 bytes)
+[debug] [2025-05-22T13:56:19.899Z] [unzip] Processing entry: client/assets/index-ClZTY_JS.js.map
+[debug] [2025-05-22T13:56:19.899Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets
+[debug] [2025-05-22T13:56:19.899Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/index-ClZTY_JS.js.map
+[debug] [2025-05-22T13:56:19.969Z] [unzip] Entry: client/assets/index-ClZTY_JS.js (compressed_size=567195 bytes, uncompressed_size=2035940 bytes)
+[debug] [2025-05-22T13:56:19.970Z] [unzip] Processing entry: client/assets/index-ClZTY_JS.js
+[debug] [2025-05-22T13:56:19.970Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets
+[debug] [2025-05-22T13:56:19.970Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/index-ClZTY_JS.js
+[debug] [2025-05-22T13:56:19.983Z] [unzip] Entry: client/assets/index-BdgySamB.css (compressed_size=35979 bytes, uncompressed_size=298654 bytes)
+[debug] [2025-05-22T13:56:19.983Z] [unzip] Processing entry: client/assets/index-BdgySamB.css
+[debug] [2025-05-22T13:56:19.983Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets
+[debug] [2025-05-22T13:56:19.983Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/index-BdgySamB.css
+[debug] [2025-05-22T13:56:19.985Z] [unzip] Entry: client/assets/extensions/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T13:56:19.985Z] [unzip] Processing entry: client/assets/extensions/
+[debug] [2025-05-22T13:56:19.985Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/extensions/
+[debug] [2025-05-22T13:56:19.986Z] [unzip] Entry: client/assets/extensions/default-extension.png (compressed_size=1646 bytes, uncompressed_size=1657 bytes)
+[debug] [2025-05-22T13:56:19.986Z] [unzip] Processing entry: client/assets/extensions/default-extension.png
+[debug] [2025-05-22T13:56:19.986Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/extensions
+[debug] [2025-05-22T13:56:19.986Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/extensions/default-extension.png
+[debug] [2025-05-22T13:56:19.986Z] [unzip] Entry: client/assets/img/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T13:56:19.986Z] [unzip] Processing entry: client/assets/img/
+[debug] [2025-05-22T13:56:19.986Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/img/
+[debug] [2025-05-22T13:56:19.987Z] [unzip] Entry: client/assets/img/database.png (compressed_size=29449 bytes, uncompressed_size=29988 bytes)
+[debug] [2025-05-22T13:56:19.987Z] [unzip] Processing entry: client/assets/img/database.png
+[debug] [2025-05-22T13:56:19.987Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/img
+[debug] [2025-05-22T13:56:19.987Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/img/database.png
+[debug] [2025-05-22T13:56:19.987Z] [unzip] Entry: client/assets/provider-icons/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T13:56:19.987Z] [unzip] Processing entry: client/assets/provider-icons/
+[debug] [2025-05-22T13:56:19.987Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/
+[debug] [2025-05-22T13:56:19.988Z] [unzip] Entry: client/assets/provider-icons/auth_service_saml.svg (compressed_size=575 bytes, uncompressed_size=1226 bytes)
+[debug] [2025-05-22T13:56:19.988Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_saml.svg
+[debug] [2025-05-22T13:56:19.988Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T13:56:19.988Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_saml.svg
+[debug] [2025-05-22T13:56:19.989Z] [unzip] Entry: client/assets/provider-icons/auth_service_phone.svg (compressed_size=261 bytes, uncompressed_size=414 bytes)
+[debug] [2025-05-22T13:56:19.989Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_phone.svg
+[debug] [2025-05-22T13:56:19.989Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T13:56:19.989Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_phone.svg
+[debug] [2025-05-22T13:56:19.990Z] [unzip] Entry: client/assets/provider-icons/auth_service_facebook.svg (compressed_size=289 bytes, uncompressed_size=457 bytes)
+[debug] [2025-05-22T13:56:19.990Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_facebook.svg
+[debug] [2025-05-22T13:56:19.990Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T13:56:19.990Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_facebook.svg
+[debug] [2025-05-22T13:56:19.991Z] [unzip] Entry: client/assets/provider-icons/auth_service_game_center.svg (compressed_size=991 bytes, uncompressed_size=3921 bytes)
+[debug] [2025-05-22T13:56:19.991Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_game_center.svg
+[debug] [2025-05-22T13:56:19.991Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T13:56:19.991Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_game_center.svg
+[debug] [2025-05-22T13:56:19.992Z] [unzip] Entry: client/assets/provider-icons/auth_service_apple.svg (compressed_size=230 bytes, uncompressed_size=334 bytes)
+[debug] [2025-05-22T13:56:19.992Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_apple.svg
+[debug] [2025-05-22T13:56:19.992Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T13:56:19.992Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_apple.svg
+[debug] [2025-05-22T13:56:19.992Z] [unzip] Entry: client/assets/provider-icons/auth_service_github.svg (compressed_size=466 bytes, uncompressed_size=838 bytes)
+[debug] [2025-05-22T13:56:19.992Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_github.svg
+[debug] [2025-05-22T13:56:19.992Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T13:56:19.993Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_github.svg
+[debug] [2025-05-22T13:56:19.993Z] [unzip] Entry: client/assets/provider-icons/auth_service_mslive.svg (compressed_size=203 bytes, uncompressed_size=378 bytes)
+[debug] [2025-05-22T13:56:19.993Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_mslive.svg
+[debug] [2025-05-22T13:56:19.993Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T13:56:19.993Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_mslive.svg
+[debug] [2025-05-22T13:56:19.994Z] [unzip] Entry: client/assets/provider-icons/auth_service_yahoo.svg (compressed_size=577 bytes, uncompressed_size=1182 bytes)
+[debug] [2025-05-22T13:56:19.994Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_yahoo.svg
+[debug] [2025-05-22T13:56:19.994Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T13:56:19.994Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_yahoo.svg
+[debug] [2025-05-22T13:56:19.994Z] [unzip] Entry: client/assets/provider-icons/auth_service_twitter.svg (compressed_size=444 bytes, uncompressed_size=751 bytes)
+[debug] [2025-05-22T13:56:19.994Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_twitter.svg
+[debug] [2025-05-22T13:56:19.994Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T13:56:19.995Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_twitter.svg
+[debug] [2025-05-22T13:56:19.995Z] [unzip] Entry: client/assets/provider-icons/auth_service_play_games.svg (compressed_size=565 bytes, uncompressed_size=1173 bytes)
+[debug] [2025-05-22T13:56:19.995Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_play_games.svg
+[debug] [2025-05-22T13:56:19.995Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T13:56:19.995Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_play_games.svg
+[debug] [2025-05-22T13:56:19.996Z] [unzip] Entry: client/assets/provider-icons/auth_service_email.svg (compressed_size=228 bytes, uncompressed_size=326 bytes)
+[debug] [2025-05-22T13:56:19.996Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_email.svg
+[debug] [2025-05-22T13:56:19.996Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T13:56:19.996Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_email.svg
+[debug] [2025-05-22T13:56:19.997Z] [unzip] Entry: client/assets/provider-icons/auth_service_google.svg (compressed_size=409 bytes, uncompressed_size=720 bytes)
+[debug] [2025-05-22T13:56:19.997Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_google.svg
+[debug] [2025-05-22T13:56:19.997Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T13:56:19.997Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_google.svg
+[debug] [2025-05-22T13:56:19.998Z] [unzip] Entry: client/assets/provider-icons/auth_service_oidc.svg (compressed_size=414 bytes, uncompressed_size=858 bytes)
+[debug] [2025-05-22T13:56:19.998Z] [unzip] Processing entry: client/assets/provider-icons/auth_service_oidc.svg
+[debug] [2025-05-22T13:56:19.998Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons
+[debug] [2025-05-22T13:56:19.998Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/assets/provider-icons/auth_service_oidc.svg
+[debug] [2025-05-22T13:56:19.998Z] [unzip] Entry: client/browserconfig.xml (compressed_size=491 bytes, uncompressed_size=822 bytes)
+[debug] [2025-05-22T13:56:19.998Z] [unzip] Processing entry: client/browserconfig.xml
+[debug] [2025-05-22T13:56:19.998Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T13:56:19.998Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/client/browserconfig.xml
+[debug] [2025-05-22T13:56:19.999Z] [unzip] Entry: client/favicon-32x32.png (compressed_size=475 bytes, uncompressed_size=475 bytes)
+[debug] [2025-05-22T13:56:19.999Z] [unzip] Processing entry: client/favicon-32x32.png
+[debug] [2025-05-22T13:56:19.999Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/client
+[debug] [2025-05-22T13:56:19.999Z] [unzip] Writing file: /root/.cache/firebase/emulators/ui-v1.14.0/client/favicon-32x32.png
+[debug] [2025-05-22T13:56:19.999Z] [unzip] Entry: server/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T13:56:19.999Z] [unzip] Processing entry: server/
+[debug] [2025-05-22T13:56:19.999Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server/
+[debug] [2025-05-22T13:56:19.999Z] [unzip] Entry: server/server.mjs.map (compressed_size=296496 bytes, uncompressed_size=1355667 bytes)
+[debug] [2025-05-22T13:56:20.000Z] [unzip] Processing entry: server/server.mjs.map
+[debug] [2025-05-22T13:56:20.000Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server
+[debug] [2025-05-22T13:56:20.000Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/server/server.mjs.map
+[debug] [2025-05-22T13:56:20.008Z] [unzip] Entry: server/server.mjs (compressed_size=315701 bytes, uncompressed_size=1172682 bytes)
+[debug] [2025-05-22T13:56:20.009Z] [unzip] Processing entry: server/server.mjs
+[debug] [2025-05-22T13:56:20.009Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server
+[debug] [2025-05-22T13:56:20.009Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/server/server.mjs
+[debug] [2025-05-22T13:56:20.018Z] [unzip] Entry: server/assets/ (compressed_size=0 bytes, uncompressed_size=0 bytes)
+[debug] [2025-05-22T13:56:20.018Z] [unzip] Processing entry: server/assets/
+[debug] [2025-05-22T13:56:20.018Z] [unzip] mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server/assets/
+[debug] [2025-05-22T13:56:20.018Z] [unzip] Entry: server/assets/multipart-parser-DGCUZdXu.mjs.map (compressed_size=4791 bytes, uncompressed_size=17918 bytes)
+[debug] [2025-05-22T13:56:20.018Z] [unzip] Processing entry: server/assets/multipart-parser-DGCUZdXu.mjs.map
+[debug] [2025-05-22T13:56:20.018Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server/assets
+[debug] [2025-05-22T13:56:20.018Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/server/assets/multipart-parser-DGCUZdXu.mjs.map
+[debug] [2025-05-22T13:56:20.019Z] [unzip] Entry: server/assets/multipart-parser-DGCUZdXu.mjs (compressed_size=2621 bytes, uncompressed_size=10390 bytes)
+[debug] [2025-05-22T13:56:20.019Z] [unzip] Processing entry: server/assets/multipart-parser-DGCUZdXu.mjs
+[debug] [2025-05-22T13:56:20.019Z] [unzip] else mkdir: /root/.cache/firebase/emulators/ui-v1.14.0/server/assets
+[debug] [2025-05-22T13:56:20.019Z] [unzip] deflating: /root/.cache/firebase/emulators/ui-v1.14.0/server/assets/multipart-parser-DGCUZdXu.mjs
+[debug] [2025-05-22T13:56:20.022Z] Could not find VSCode notification endpoint: FetchError: request to http://localhost:40001/vscode/notify failed, reason: connect ECONNREFUSED 127.0.0.1:40001. If you are not running the Firebase Data Connect VSCode extension, this is expected and not an issue.
+[info] 
+┌─────────────────────────────────────────────────────────────┐
+│ ✔  All emulators ready! It is now safe to connect your app. │
+│ i  View Emulator UI at http://127.0.0.1:4000/               │
+└─────────────────────────────────────────────────────────────┘
+
+┌───────────┬──────────────────────────────────┬─────────────────────┐
+│ Emulator  │ Host:Port                        │ View in Emulator UI │
+├───────────┼──────────────────────────────────┼─────────────────────┤
+│ Functions │ Failed to initialize (see above) │                     │
+└───────────┴──────────────────────────────────┴─────────────────────┘
+  Emulator Hub host: 127.0.0.1 port: 4400
+  Other reserved ports: 4500
+
+Issues? Report them at https://github.com/firebase/firebase-tools/issues and attach the *-debug.log files.
+ 

--- a/functions/src/categorizeQuestion.ts
+++ b/functions/src/categorizeQuestion.ts
@@ -55,7 +55,6 @@ export const categorizeQuestion = functions.firestore
       );
 
       // パースする前にステータスと生のテキストを確認
-      // (ポートフォリオ提出時には、以下の2行のlogはコメントアウトまたは削除しても良いかもしれません)
       console.log("API Response Status:", res.status);
       const rawText = await res.text();
       console.log("API Raw Response Text:", rawText);


### PR DESCRIPTION
AdminDashboard.tsx を新規作成

Firestoreから全質問を取得し、questionId の降順で表示

ステータスに応じて文字色を変更（未対応は黒、対応済みは灰色）

カラム構成：ID、カテゴリ、学科、学年、投稿日時、ステータス、対応者

AdminQuestionDetail.tsx を新規作成

Firestoreのデータを取得して詳細表示

回答文の記入・送信処理（Firestore更新＋archives/保存）

ステータスがrepliedの場合はテキストエリアを読み取り専用に

回答者名（repliedBy）と回答内容の表示追加

「戻る」ボタンを中央に配置

App.tsx にルーティング追加

/admin/dashboard と /admin/dashboard/detail/:id を登録